### PR TITLE
Promiscuous::Worker -> Promiscuous::Subscriber::Worker

### DIFF
--- a/lib/promiscuous.rb
+++ b/lib/promiscuous.rb
@@ -9,6 +9,7 @@ module Promiscuous
   autoload :Publisher,  'promiscuous/publisher'
   autoload :Subscriber, 'promiscuous/subscriber'
   autoload :Observer,   'promiscuous/observer'
+  autoload :Worker,     'promiscuous/worker'
 
   class << self
     def configure(&block)

--- a/lib/promiscuous/common.rb
+++ b/lib/promiscuous/common.rb
@@ -2,4 +2,5 @@ module Promiscuous::Common
   autoload :Options,      'promiscuous/common/options'
   autoload :Lint,         'promiscuous/common/lint'
   autoload :ClassHelpers, 'promiscuous/common/class_helpers'
+  autoload :Worker,       'promiscuous/common/worker'
 end

--- a/lib/promiscuous/common/worker.rb
+++ b/lib/promiscuous/common/worker.rb
@@ -1,0 +1,17 @@
+module Promiscuous::Common::Worker
+  extend ActiveSupport::Concern
+
+  def initialize
+    self.stop = false
+  end
+
+  def unit_of_work
+    if defined?(Mongoid)
+      Mongoid.unit_of_work { yield }
+    else
+      yield
+    end
+  end
+
+  included { attr_accessor :stop }
+end

--- a/lib/promiscuous/publisher/amqp.rb
+++ b/lib/promiscuous/publisher/amqp.rb
@@ -2,7 +2,7 @@ module Promiscuous::Publisher::AMQP
   extend ActiveSupport::Concern
   include Promiscuous::Publisher::Envelope
 
-  def amqp_publish
+  def publish
     Promiscuous::AMQP.publish(:key => to, :payload => payload.to_json)
   end
 

--- a/lib/promiscuous/publisher/model.rb
+++ b/lib/promiscuous/publisher/model.rb
@@ -33,7 +33,7 @@ module Promiscuous::Publisher::Model
         [:create, :update, :destroy].each do |operation|
           __send__("after_#{operation}", "promiscuous_publish_#{operation}".to_sym)
           define_method "promiscuous_publish_#{operation}" do
-            self.class.promiscuous_publisher.new(:instance => self, :operation => operation).amqp_publish
+            self.class.promiscuous_publisher.new(:instance => self, :operation => operation).publish
           end
         end
         alias :promiscuous_sync :promiscuous_publish_update

--- a/lib/promiscuous/railtie/replicate.rake
+++ b/lib/promiscuous/railtie/replicate.rake
@@ -1,18 +1,33 @@
 namespace :promiscuous do
-  desc 'Run the subscribers worker'
+  # Note This rake task can be loaded without Rails
+  desc 'Run the workers'
   task :replicate => :environment do |t|
-    require 'promiscuous/worker'
     require 'eventmachine'
     require 'em-synchrony'
 
     EM.synchrony do
-      Promiscuous::Loader.load_descriptors :subscribers if defined?(Rails)
-      Promiscuous::AMQP.disconnect
-      Promiscuous::Config.backend = :rubyamqp
-      Promiscuous::AMQP.connect
+      trap_signals
+      force_backend :rubyamqp
 
-      Promiscuous::Worker.replicate
+      Promiscuous::Loader.load_descriptors if defined?(Rails)
+
+      Promiscuous::Subscriber::Worker.replicate
       $stderr.puts "Replicating with #{Promiscuous::Subscriber::AMQP.subscribers.count} subscribers"
     end
+  end
+
+  def trap_signals
+    %w(SIGTERM SIGINT).each do |signal|
+      Signal.trap(signal) do
+        Promiscuous.info "Exiting..."
+        EM.stop
+      end
+    end
+  end
+
+  def force_backend(backend)
+    Promiscuous::AMQP.disconnect
+    Promiscuous::Config.backend = backend
+    Promiscuous::AMQP.connect
   end
 end

--- a/lib/promiscuous/subscriber.rb
+++ b/lib/promiscuous/subscriber.rb
@@ -12,6 +12,7 @@ module Promiscuous::Subscriber
   autoload :Polymorphic,  'promiscuous/subscriber/polymorphic'
   autoload :Upsert,       'promiscuous/subscriber/upsert'
   autoload :Observer,     'promiscuous/subscriber/observer'
+  autoload :Worker,       'promiscuous/subscriber/worker'
 
   def self.lint(*args)
     Lint.lint(*args)

--- a/lib/promiscuous/subscriber/worker.rb
+++ b/lib/promiscuous/subscriber/worker.rb
@@ -1,0 +1,38 @@
+class Promiscuous::Subscriber::Worker
+  include Promiscuous::Common::Worker
+
+  def replicate
+    Promiscuous::AMQP.subscribe(subscribe_options) do |metadata, payload|
+      begin
+        unless self.stop
+          # FIXME Investigate: Do we need a mutex around the mongo query ?
+          # It wouldn't be surprising that we keep pumping messages while mongo
+          # blocks on the socket.
+          # If Mongoid uses a poll of connections, we most likely need to
+          # serialize. Note that If we do, we just need it during save!
+          # TODO Maybe we could offer different levels of consistency, because
+          # some of our users may already be resilient to reading out of order
+          # writes.
+
+          Promiscuous.info "[receive] #{payload}"
+          self.unit_of_work { Promiscuous::Subscriber.process(JSON.parse(payload)) }
+          metadata.ack
+        end
+      rescue Exception => e
+        e = Promiscuous::Subscriber::Error.new(e, payload)
+
+        # TODO Discuss with Arjun about having an error queue.
+        self.stop = true
+        Promiscuous::AMQP.disconnect
+        Promiscuous.error "[receive] FATAL #{e}"
+        Promiscuous::Config.error_handler.try(:call, e)
+      end
+    end
+  end
+
+  def subscribe_options
+    queue_name = "#{Promiscuous::Config.app}.promiscuous"
+    bindings = Promiscuous::Subscriber::AMQP.subscribers.keys
+    {:queue_name => queue_name, :bindings => bindings}
+  end
+end

--- a/lib/promiscuous/worker.rb
+++ b/lib/promiscuous/worker.rb
@@ -1,51 +1,14 @@
-module Promiscuous
-  module Worker
-    mattr_accessor :stop
+module Promiscuous::Worker
+  mattr_accessor :workers
+  self.workers = []
 
-    def self.replicate
-      self.stop = false
-      self.trap_signals unless ENV['TEST_ENV']
+  def self.replicate
+    self.workers << Promiscuous::Subscriber::Worker.new
+    self.workers.each { |w| w.replicate }
+  end
 
-      Promiscuous::AMQP.subscribe(subscribe_options) do |metadata, payload|
-        begin
-          unless self.stop
-            Promiscuous.info "[receive] #{payload}"
-            self.mongoid_wrapper { Promiscuous::Subscriber.process(JSON.parse(payload)) }
-            metadata.ack
-          end
-        rescue Exception => e
-          e = Promiscuous::Subscriber::Error.new(e, payload)
-
-          self.stop = true
-          Promiscuous::AMQP.disconnect
-          Promiscuous.error "[receive] FATAL #{e}"
-          Promiscuous::Config.error_handler.call(e) if Promiscuous::Config.error_handler
-        end
-      end
-    end
-
-    def self.mongoid_wrapper
-      if defined?(Mongoid)
-        Mongoid.unit_of_work { yield }
-      else
-        yield
-      end
-    end
-
-    def self.trap_signals
-      %w(SIGTERM SIGINT).each do |signal|
-        Signal.trap(signal) do
-          self.stop = true
-          EM.stop
-          Promiscuous.info "exiting gracefully"
-        end
-      end
-    end
-
-    def self.subscribe_options
-      queue_name = "#{Promiscuous::Config.app}.promiscuous"
-      bindings = Promiscuous::Subscriber::AMQP.subscribers.keys
-      {:queue_name => queue_name, :bindings => bindings}
-    end
+  def self.stop
+    self.workers.each { |w| w.stop = true }
+    self.workers.clear
   end
 end

--- a/spec/integration/basic_spec.rb
+++ b/spec/integration/basic_spec.rb
@@ -1,5 +1,4 @@
 require 'spec_helper'
-require 'promiscuous/worker'
 
 describe Promiscuous do
   before { load_models }

--- a/spec/integration/embedded_spec.rb
+++ b/spec/integration/embedded_spec.rb
@@ -1,5 +1,4 @@
 require 'spec_helper'
-require 'promiscuous/worker'
 
 if ORM.has(:embedded_documents)
   describe Promiscuous do

--- a/spec/integration/error_spec.rb
+++ b/spec/integration/error_spec.rb
@@ -1,5 +1,4 @@
 require 'spec_helper'
-require 'promiscuous/worker'
 
 describe Promiscuous do
   before { load_models }

--- a/spec/integration/foreign_key_spec.rb
+++ b/spec/integration/foreign_key_spec.rb
@@ -1,5 +1,4 @@
 require 'spec_helper'
-require 'promiscuous/worker'
 
 describe Promiscuous do
   before { load_models }

--- a/spec/integration/observer_spec.rb
+++ b/spec/integration/observer_spec.rb
@@ -1,5 +1,4 @@
 require 'spec_helper'
-require 'promiscuous/worker'
 
 describe Promiscuous do
   before { load_models; load_observers }

--- a/spec/integration/polymorphic_embedded_spec.rb
+++ b/spec/integration/polymorphic_embedded_spec.rb
@@ -1,5 +1,4 @@
 require 'spec_helper'
-require 'promiscuous/worker'
 
 if ORM.has(:embedded_documents) and ORM.has(:polymorphic)
   describe Promiscuous do

--- a/spec/integration/polymorphic_spec.rb
+++ b/spec/integration/polymorphic_spec.rb
@@ -1,5 +1,4 @@
 require 'spec_helper'
-require 'promiscuous/worker'
 
 if ORM.has(:polymorphic)
   describe Promiscuous do

--- a/spec/integration/upsert_spec.rb
+++ b/spec/integration/upsert_spec.rb
@@ -1,5 +1,4 @@
 require 'spec_helper'
-require 'promiscuous/worker'
 
 describe Promiscuous do
   before { load_models }

--- a/spec/unit/promiscuous/subscribers/worker_spec.rb
+++ b/spec/unit/promiscuous/subscribers/worker_spec.rb
@@ -1,7 +1,6 @@
 require 'spec_helper'
-require 'promiscuous/worker'
 
-describe Promiscuous::Worker, '.subscribe' do
+describe Promiscuous::Subscriber::Worker, '.subscribe' do
   before { load_models }
   before { use_null_amqp(:app => 'test_subscriber') }
 
@@ -18,14 +17,11 @@ describe Promiscuous::Worker, '.subscribe' do
     end
   end
 
-  before { Promiscuous::Worker.replicate }
+  let(:sub_worker) { Promiscuous::Subscriber::Worker.new }
+  before { sub_worker.replicate }
 
   it 'subscribes to the correct queue' do
     queue_name = 'test_subscriber.promiscuous'
-    Promiscuous::Worker.subscribe_options[:queue_name].should == queue_name
-  end
-
-  after do
-    Promiscuous::Subscriber::AMQP.subscribers.clear
+    sub_worker.subscribe_options[:queue_name].should == queue_name
   end
 end


### PR DESCRIPTION
Code changes:
  1) Trapping signals is done in the rake task which now both start and
     stop the reactor.
  2) unit_of_work has been extracted since all workers should use it.

Concerns:
  Do we need a mutex around the mongo update when replicating
  subscribers ?
  It wouldn't be surprising that we keep pumping messages while mongo
  blocks on the socket.
  If Mongoid uses a poll of connections, we most likely need to
  serialize. Note that If we do, we just need it during save!

  Maybe we could offer different levels of consistency, because
  some of our users may already be resilient to reading out of order
  writes.
