### PR TITLE
Refactoring AMQP miscellaneous stuff

### DIFF
--- a/lib/promiscuous/amqp/rubyamqp.rb
+++ b/lib/promiscuous/amqp/rubyamqp.rb
@@ -11,12 +11,12 @@ module Promiscuous
           raise "Please use amqp://user:password@host:port/vhost" if uri.scheme != 'amqp'
 
           {
-            :host => uri.host,
-            :port => uri.port,
+            :host   => uri.host,
+            :port   => uri.port,
             :scheme => uri.scheme,
-            :user => uri.user,
-            :pass => uri.password,
-            :vhost => uri.path.empty? ? "/" : uri.path,
+            :user   => uri.user,
+            :pass   => uri.password,
+            :vhost  => uri.path.empty? ? "/" : uri.path,
          }
         end
 
@@ -26,7 +26,8 @@ module Promiscuous
       end
 
       def self.disconnect
-        channel.close
+        self.channel.close if self.channel
+        self.channel = nil
       end
 
       def self.subscribe(options={}, &block)

--- a/lib/promiscuous/subscriber/amqp.rb
+++ b/lib/promiscuous/subscriber/amqp.rb
@@ -16,7 +16,7 @@ module Promiscuous::Subscriber::AMQP
   included { use_option :from }
 
   module ClassMethods
-    def from=(value)
+    def from=(_)
       super
       old_sub = Promiscuous::Subscriber::AMQP.subscribers[from]
       raise "The subscriber '#{old_sub}' already listen on '#{from}'" if old_sub


### PR DESCRIPTION
When we disconnect, we want to cleanup the channel, because otherwise we
might still be able to communicate with rabbit.
