### PR TITLE
Embedded documents ID update fix

### DIFF
--- a/lib/promiscuous/subscriber/mongoid/embedded.rb
+++ b/lib/promiscuous/subscriber/mongoid/embedded.rb
@@ -2,9 +2,7 @@ module Promiscuous::Subscriber::Mongoid::Embedded
   extend ActiveSupport::Concern
 
   def fetch
-    instance = old_value.nil? ? klass.new : old_value
-    instance.id = id
-    instance
+    (old_value || klass.new).tap { |m| m.id = id }
   end
 
   def old_value

--- a/lib/promiscuous/subscriber/mongoid/embedded.rb
+++ b/lib/promiscuous/subscriber/mongoid/embedded.rb
@@ -2,7 +2,9 @@ module Promiscuous::Subscriber::Mongoid::Embedded
   extend ActiveSupport::Concern
 
   def fetch
-    old_value.nil? ? klass.new.tap { |m| m.id = id } : old_value
+    instance = old_value.nil? ? klass.new : old_value
+    instance.id = id
+    instance
   end
 
   def old_value

--- a/spec/integration/embedded_spec.rb
+++ b/spec/integration/embedded_spec.rb
@@ -87,6 +87,22 @@ if ORM.has(:embedded_documents)
           pub = PublisherModelEmbed.create(:field_1 => '1',
                                            :model_embedded => { :embedded_field_1 => 'e1',
                                                                 :embedded_field_2 => 'e2' })
+          pub_e = pub.model_embedded
+
+          eventually do
+            sub = SubscriberModelEmbed.first
+            sub.id.should == pub.id
+            sub.field_1.should == pub.field_1
+            sub.field_2.should == pub.field_2
+            sub.field_3.should == pub.field_3
+
+            sub_e = sub.model_embedded
+            sub_e.id.should == pub_e.id
+            sub_e.embedded_field_1.should == pub_e.embedded_field_1
+            sub_e.embedded_field_2.should == pub_e.embedded_field_2
+            sub_e.embedded_field_3.should == pub_e.embedded_field_3
+          end
+
           pub.model_embedded = PublisherModelEmbeddedChild.new(:embedded_field_1 => 'e1_updated')
           pub.save
 


### PR DESCRIPTION
When the embedded document ID changes, without going through the step
where the embedded document is empty, we should update the ID properly.
