### PR TITLE
Deferrable updates for mongoid3

### DIFF
--- a/lib/promiscuous/publisher.rb
+++ b/lib/promiscuous/publisher.rb
@@ -10,6 +10,8 @@ module Promiscuous::Publisher
   autoload :Model,        'promiscuous/publisher/model'
   autoload :Mongoid,      'promiscuous/publisher/mongoid'
   autoload :Polymorphic,  'promiscuous/publisher/polymorphic'
+  autoload :Worker,       'promiscuous/publisher/worker'
+  autoload :Error,        'promiscuous/publisher/error'
 
   def self.lint(*args)
     Lint.lint(*args)

--- a/lib/promiscuous/publisher/error.rb
+++ b/lib/promiscuous/publisher/error.rb
@@ -1,0 +1,18 @@
+class Promiscuous::Publisher::Error < RuntimeError
+  attr_accessor :inner, :instance
+
+  def initialize(inner, instance)
+    super(inner)
+    set_backtrace(inner.backtrace)
+    self.inner = inner
+    self.instance = instance
+  end
+
+  def message
+    "#{inner.message} while processing #{instance}"
+  end
+
+  def to_s
+    message
+  end
+end

--- a/lib/promiscuous/publisher/mongoid.rb
+++ b/lib/promiscuous/publisher/mongoid.rb
@@ -1,5 +1,6 @@
 class Promiscuous::Publisher::Mongoid < Promiscuous::Publisher::Base
   autoload :Embedded, 'promiscuous/publisher/mongoid/embedded'
+  autoload :Defer,    'promiscuous/publisher/mongoid/defer'
 
   include Promiscuous::Publisher::Class
   include Promiscuous::Publisher::Attributes
@@ -13,6 +14,11 @@ class Promiscuous::Publisher::Mongoid < Promiscuous::Publisher::Base
       include Promiscuous::Publisher::Mongoid::Embedded
     else
       include Promiscuous::Publisher::Model
+      include Promiscuous::Publisher::Mongoid::Defer if mongoid3?
     end
+  end
+
+  def self.mongoid3?
+    Gem.loaded_specs['mongoid'].version >= Gem::Version.new('3.0.0')
   end
 end

--- a/lib/promiscuous/publisher/mongoid/defer.rb
+++ b/lib/promiscuous/publisher/mongoid/defer.rb
@@ -1,0 +1,52 @@
+module Promiscuous::Publisher::Mongoid::Defer
+  extend ActiveSupport::Concern
+
+  mattr_accessor :klasses
+  self.klasses = {}
+
+  def publish
+    super unless should_defer?
+  end
+
+  def should_defer?
+    if options.has_key?(:defer)
+      options[:defer]
+    else
+      operation == :update
+    end
+  end
+
+  def self.hook_mongoid
+    return if @mongoid_hooked
+    @mongoid_hooked = true
+
+    Moped::Query.class_eval do
+      alias_method :update_orig, :update
+      def update(change, flags = nil)
+        if klass = Promiscuous::Publisher::Mongoid::Defer.klasses[@collection.name]
+          psp_field = klass.aliased_fields["promiscous_sync_pending"]
+          change = change.dup
+          change['$set'] ||= {}
+          change['$set'].merge!(psp_field => true)
+        end
+        update_orig(change, flags)
+      end
+    end
+  end
+
+  included do
+    klass.class_eval do
+      cattr_accessor :publisher_defer_hooked
+      return if self.publisher_defer_hooked
+      self.publisher_defer_hooked = true
+
+      # TODO Make sure we are not overriding a field, although VERY unlikly
+      psp_field = :_psp
+      field psp_field, :as => :promiscous_sync_pending, :type => Boolean
+      index({psp_field => 1}, :background => true, :sparse => true)
+
+      Promiscuous::Publisher::Mongoid::Defer.hook_mongoid
+      Promiscuous::Publisher::Mongoid::Defer.klasses[collection.name] = self
+    end
+  end
+end

--- a/lib/promiscuous/publisher/worker.rb
+++ b/lib/promiscuous/publisher/worker.rb
@@ -1,0 +1,47 @@
+class Promiscuous::Publisher::Worker
+  include Promiscuous::Common::Worker
+
+  def self.poll_delay
+    # TODO Configurable globally
+    # TODO Configurable per publisher
+    1.second
+  end
+
+  def replicate
+    EM.defer proc { self.replicate_once },
+             proc { EM::Timer.new(self.class.poll_delay) { replicate } }
+  end
+
+  def replicate_once
+    return if self.stop
+    begin
+      self.unit_of_work do
+        Promiscuous::Publisher::Mongoid::Defer.klasses.values.each do |klass|
+          replicate_collection(klass)
+        end
+      end
+    rescue Exception => e
+      self.stop = true
+      unless e.is_a?(Promiscuous::Publisher::Error)
+        e = Promiscuous::Publisher::Error.new(e, nil)
+      end
+      Promiscuous.error "[publish] FATAL #{e}"
+      Promiscuous::Config.error_handler.try(:call, e)
+    end
+  end
+
+  def replicate_collection(klass)
+    return if self.stop
+    psp_field = klass.aliased_fields["promiscous_sync_pending"]
+    while instance = klass.where(psp_field => true).find_and_modify({'$unset' => {psp_field => 1}})
+      replicate_instance(instance)
+    end
+  end
+
+  def replicate_instance(instance)
+    return if self.stop
+    instance.class.promiscuous_publisher.new(:instance => instance, :operation => :update, :defer => false).publish
+  rescue Exception => e
+    raise Promiscuous::Publisher::Error.new(e, instance)
+  end
+end

--- a/lib/promiscuous/publisher/worker.rb
+++ b/lib/promiscuous/publisher/worker.rb
@@ -32,6 +32,7 @@ class Promiscuous::Publisher::Worker
 
   def replicate_collection(klass)
     return if self.stop
+    # TODO Check for indexes and if not there, bail out
     psp_field = klass.aliased_fields["promiscous_sync_pending"]
     while instance = klass.where(psp_field => true).find_and_modify({'$unset' => {psp_field => 1}})
       replicate_instance(instance)
@@ -42,6 +43,7 @@ class Promiscuous::Publisher::Worker
     return if self.stop
     instance.class.promiscuous_publisher.new(:instance => instance, :operation => :update, :defer => false).publish
   rescue Exception => e
+    # TODO set back the psp field
     raise Promiscuous::Publisher::Error.new(e, instance)
   end
 end

--- a/lib/promiscuous/railtie/replicate.rake
+++ b/lib/promiscuous/railtie/replicate.rake
@@ -11,8 +11,12 @@ namespace :promiscuous do
 
       Promiscuous::Loader.load_descriptors if defined?(Rails)
 
-      Promiscuous::Subscriber::Worker.replicate
-      $stderr.puts "Replicating with #{Promiscuous::Subscriber::AMQP.subscribers.count} subscribers"
+      Promiscuous::Worker.replicate
+
+      msg = "Replicating with #{Promiscuous::Subscriber::AMQP.subscribers.count} subscribers" +
+            " and #{Promiscuous::Publisher::Mongoid::Defer.klasses.count} publishers"
+      Promiscuous.info msg
+      $stderr.puts msg
     end
   end
 
@@ -20,6 +24,7 @@ namespace :promiscuous do
     %w(SIGTERM SIGINT).each do |signal|
       Signal.trap(signal) do
         Promiscuous.info "Exiting..."
+        Promiscuous::Worker.stop
         EM.stop
       end
     end

--- a/lib/promiscuous/worker.rb
+++ b/lib/promiscuous/worker.rb
@@ -3,6 +3,7 @@ module Promiscuous::Worker
   self.workers = []
 
   def self.replicate
+    self.workers << Promiscuous::Publisher::Worker.new
     self.workers << Promiscuous::Subscriber::Worker.new
     self.workers.each { |w| w.replicate }
   end

--- a/spec/integration/defer_spec.rb
+++ b/spec/integration/defer_spec.rb
@@ -1,0 +1,77 @@
+require 'spec_helper'
+
+if ORM.has(:pub_deferred_updates)
+  describe Promiscuous do
+    before { load_models }
+    before { use_real_amqp }
+
+    before do
+      define_constant('Publisher', ORM::PublisherBase) do
+        publish :to => 'crowdtap/publisher_model',
+          :class => :PublisherModel,
+          :attributes => [:field_1, :field_2, :field_3]
+      end
+
+      define_constant('Subscriber', ORM::SubscriberBase) do
+        subscribe :from => 'crowdtap/publisher_model',
+          :class => :SubscriberModel,
+          :attributes => [:field_1, :field_2, :field_3]
+      end
+    end
+
+    before { Promiscuous::Worker.replicate }
+
+    context 'when publishing' do
+      context 'when updating' do
+        it 'replicates' do
+          2.times do
+            3.times do
+              pub = PublisherModel.create(:field_1 => '1', :field_2 => '2', :field_3 => '3')
+              pub.update_attributes(:field_1 => '1_updated', :field_2 => '2_updated')
+            end
+
+            eventually do
+              PublisherModel.each do |pub|
+                sub = SubscriberModel.find(pub.id)
+                sub.field_1.should == pub.field_1
+                sub.field_2.should == pub.field_2
+                sub.field_3.should == pub.field_3
+              end
+            end
+          end
+        end
+
+        it 'eventually leaves the published model intact' do
+          pub = PublisherModel.create(:field_1 => '1', :field_2 => '2', :field_3 => '3')
+          pub.update_attributes(:field_1 => '1_updated', :field_2 => '2_updated')
+          eventually do
+            sub = SubscriberModel.first
+            sub.field_1.should == pub.field_1
+            pub.reload
+            pub.promiscous_sync_pending.should == nil
+          end
+        end
+
+        it 'replicates increments properly, even with high concurrency' do
+          pub = PublisherModel.create(:field_1 => 0)
+          100.times { EM.defer { pub.inc(:field_1, 1) } }
+          eventually { SubscriberModel.first.field_1.should == 100 }
+        end
+      end
+    end
+
+    context 'when not publishing some models' do
+      it 'does not set the promiscous_sync_pending' do
+        PublisherModel.create(:field_1 => '1', :field_2 => '2', :field_3 => '3')
+        eventually do
+          SubscriberModel.first.should_not == nil
+        end
+
+        pub = PublisherModelOther.create(:field_1 => '1', :field_2 => '2', :field_3 => '3')
+        pub.update_attributes(:field_1 => '1_updated', :field_2 => '2_updated')
+        pub.reload
+        pub.attributes.keys.should =~ ["_id", "field_1", "field_2", "field_3"]
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -25,6 +25,12 @@ RSpec.configure do |config|
     Promiscuous::AMQP.disconnect
     Promiscuous::Worker.stop
     Promiscuous::Subscriber::AMQP.subscribers.clear
+    Promiscuous::Publisher::Mongoid::Defer.klasses.clear
   end
 end
 
+Promiscuous::Publisher::Worker.class_eval do
+  def self.poll_delay
+    0.1.second
+  end
+end

--- a/spec/support/models/mongoid.rb
+++ b/spec/support/models/mongoid.rb
@@ -8,6 +8,14 @@ module ModelsHelper
       field :field_3
     end
 
+    define_constant('PublisherModelOther') do
+      include Mongoid::Document
+
+      field :field_1
+      field :field_2
+      field :field_3
+    end
+
     define_constant('PublisherModelChild', PublisherModel) do
       field :child_field_1
       field :child_field_2

--- a/spec/support/orm.rb
+++ b/spec/support/orm.rb
@@ -1,10 +1,11 @@
 module ORM
   def self.has(feature)
     {
-      :active_record      => [:active_record],
-      :mongoid            => [:mongoid2, :mongoid3],
-      :polymorphic        => [:mongoid2, :mongoid3],
-      :embedded_documents => [:mongoid2, :mongoid3]
+      :active_record        => [:active_record],
+      :mongoid              => [:mongoid2, :mongoid3],
+      :polymorphic          => [:mongoid2, :mongoid3],
+      :embedded_documents   => [:mongoid2, :mongoid3],
+      :pub_deferred_updates => [:mongoid3],
     }[feature].any? { |orm| orm.to_s == ENV['TEST_ENV'] }
   end
 


### PR DESCRIPTION
Deferring updates is a trade-off:
- It is essential to prevent races with two writers (without having
  to use a locking service).
- It reduces the number of published messages since only the latest
  update will be sent in a batch, so that's good for performance.
- But it introduces a new kind of issue: messages are no longer
  guaranteed to be in order: The subscribers will have to be immune to
  receiving out of order updates.

Performance wise, it is not worth it to serialize message by the
updated_at field across collections.

Because of this drawback, we do not defer publishing model creation.
But that's just fine because the two first points are not affected
during model creation.
