### PR TITLE
Synchronization feature

### DIFF
--- a/lib/promiscuous/amqp.rb
+++ b/lib/promiscuous/amqp.rb
@@ -3,11 +3,13 @@ module Promiscuous::AMQP
   autoload :RubyAMQP, 'promiscuous/amqp/rubyamqp'
   autoload :Null,     'promiscuous/amqp/null'
 
+  EXCHANGE = 'promiscuous'.freeze
+
   class << self
     def backend
       Promiscuous::Config.backend
     end
 
-    delegate :connect, :disconnect, :publish, :subscribe, :to => :backend
+    delegate :connect, :disconnect, :publish, :open_queue, :to => :backend
   end
 end

--- a/lib/promiscuous/amqp/bunny.rb
+++ b/lib/promiscuous/amqp/bunny.rb
@@ -13,14 +13,18 @@ module Promiscuous
         self.connection.stop
       end
 
-      def self.publish(msg)
-        Promiscuous.info "[publish] #{msg[:key]} -> #{msg[:payload]}"
-        exchange = connection.exchange('promiscuous', :type => :topic, :durable => true)
-        exchange.publish(msg[:payload], :key => msg[:key], :persistent => true)
+      def self.publish(options={})
+        Promiscuous.info "[publish] (#{options[:exchange_name]}) #{options[:key]} -> #{options[:payload]}"
+        exchange(options[:exchange_name]).
+          publish(options[:payload], :key => options[:key], :persistent => true)
       end
 
-      def self.subscribe(options={}, &block)
-        raise "Cannot subscribe with bunny"
+      def self.open_queue(options={}, &block)
+        raise "Cannot open queue with bunny"
+      end
+
+      def self.exchange(name)
+        connection.exchange(name, :type => :topic, :durable => true)
       end
     end
   end

--- a/lib/promiscuous/amqp/null.rb
+++ b/lib/promiscuous/amqp/null.rb
@@ -7,10 +7,10 @@ module Promiscuous
       def self.disconnect
       end
 
-      def self.publish(msg)
+      def self.publish(msg, options={})
       end
 
-      def self.subscribe(options={}, &block)
+      def self.open_queue(options={}, &block)
       end
     end
   end

--- a/lib/promiscuous/common/worker.rb
+++ b/lib/promiscuous/common/worker.rb
@@ -1,7 +1,8 @@
 module Promiscuous::Common::Worker
   extend ActiveSupport::Concern
 
-  def initialize
+  def initialize(options={})
+    self.options = options
     self.stop = false
   end
 
@@ -13,5 +14,5 @@ module Promiscuous::Common::Worker
     end
   end
 
-  included { attr_accessor :stop }
+  included { attr_accessor :stop, :options }
 end

--- a/lib/promiscuous/publisher/amqp.rb
+++ b/lib/promiscuous/publisher/amqp.rb
@@ -3,7 +3,9 @@ module Promiscuous::Publisher::AMQP
   include Promiscuous::Publisher::Envelope
 
   def publish
-    Promiscuous::AMQP.publish(:key => to, :payload => payload.to_json)
+    exchange_name = Promiscuous::AMQP::EXCHANGE
+    exchange_name += ".#{options[:personality]}" if options[:personality]
+    Promiscuous::AMQP.publish(:exchange_name => exchange_name, :key => to, :payload => payload.to_json)
   end
 
   def payload

--- a/lib/promiscuous/publisher/model.rb
+++ b/lib/promiscuous/publisher/model.rb
@@ -36,7 +36,12 @@ module Promiscuous::Publisher::Model
             self.class.promiscuous_publisher.new(:instance => self, :operation => operation).publish
           end
         end
-        alias :promiscuous_sync :promiscuous_publish_update
+
+        def promiscuous_sync(options={})
+          options = options.merge({ :instance => self, :operation => :update, :defer => false })
+          self.class.promiscuous_publisher.new(options).publish
+          true
+        end
       end
     end
   end

--- a/lib/promiscuous/publisher/worker.rb
+++ b/lib/promiscuous/publisher/worker.rb
@@ -49,7 +49,7 @@ class Promiscuous::Publisher::Worker
 
   def replicate_instance(instance)
     return if self.stop
-    instance.class.promiscuous_publisher.new(:instance => instance, :operation => :update, :defer => false).publish
+    instance.promiscuous_sync
   rescue Exception => e
     # TODO set back the psp field
     raise Promiscuous::Publisher::Error.new(e, instance)

--- a/lib/promiscuous/railtie/replicate.rake
+++ b/lib/promiscuous/railtie/replicate.rake
@@ -1,24 +1,5 @@
 namespace :promiscuous do
-  # Note This rake task can be loaded without Rails
-  desc 'Run the workers'
-  task :replicate => :environment do |t|
-    require 'eventmachine'
-    require 'em-synchrony'
-
-    EM.synchrony do
-      trap_signals
-      force_backend :rubyamqp
-
-      Promiscuous::Loader.load_descriptors if defined?(Rails)
-
-      Promiscuous::Worker.replicate
-
-      msg = "Replicating with #{Promiscuous::Subscriber::AMQP.subscribers.count} subscribers" +
-            " and #{Promiscuous::Publisher::Mongoid::Defer.klasses.count} publishers"
-      Promiscuous.info msg
-      $stderr.puts msg
-    end
-  end
+  # Note These rake tasks can be loaded without Rails
 
   def trap_signals
     %w(SIGTERM SIGINT).each do |signal|
@@ -30,9 +11,77 @@ namespace :promiscuous do
     end
   end
 
+  def print_status(msg)
+    Promiscuous.info msg
+    $stderr.puts msg
+  end
+
   def force_backend(backend)
     Promiscuous::AMQP.disconnect
     Promiscuous::Config.backend = backend
     Promiscuous::AMQP.connect
+  end
+
+  def replicate(config_options={}, &block)
+    require 'eventmachine'
+    require 'em-synchrony'
+
+    EM.synchrony do
+      trap_signals
+      Promiscuous::Loader.load_descriptors if defined?(Rails)
+      force_backend :rubyamqp
+      block.call
+    end
+  end
+
+  desc 'Run the publisher worker'
+  task :publish => :environment do
+    replicate do
+      Promiscuous::Worker.replicate :only => :publish
+      print_status "Replicating with #{Promiscuous::Publisher::Mongoid::Defer.klasses.count} publishers"
+    end
+  end
+
+  desc 'Run the subscriber worker'
+  task :subscribe => :environment do
+    replicate do
+      Promiscuous::Worker.replicate :only => :subscribe
+      print_status "Replicating with #{Promiscuous::Subscriber::AMQP.subscribers.count} subscribers"
+    end
+  end
+
+  namespace :synchronized do
+    desc 'Synchronize a collection'
+    task :publish, [:criteria] => :environment do |t, args|
+      raise "Usage: rake promiscuous:synchronized:publish[Model]" unless args.criteria
+
+      criteria = eval(args.criteria)
+      count = criteria.count
+      print_status "Replicating #{args.criteria}..."
+
+      bar = ProgressBar.create(:format => '%t |%b>%i| %c/%C %e',
+                               :title => 'Publishing',
+                               :total => count)
+      criteria.each do |doc|
+        doc.promiscuous_sync :personality => :sync
+        bar.increment
+      end
+
+      print_status "Done. You may switch your subscriber worker back to regular mode, and delete the sync queues"
+    end
+
+    desc 'Subscribe to a collection synchronization'
+    task :subscribe => :environment do |t|
+      replicate do
+        # Create the regular queue if needed, so we don't lose messages.
+        Promiscuous::AMQP.open_queue(Promiscuous::Subscriber::Worker.new.queue_bindings)
+
+        print_status "WARNING: --- SYNC MODE ----"
+        print_status "WARNING: Make sure you are not running the regular subscriber worker (it's racy)"
+        print_status "WARNING: --- SYNC MODE ----"
+        Promiscuous::Worker.replicate :personality => :sync, :only => :subscribe
+        print_status "Replicating with #{Promiscuous::Subscriber::AMQP.subscribers.count} subscribers"
+      end
+    end
   end
 end

--- a/lib/promiscuous/subscriber/worker.rb
+++ b/lib/promiscuous/subscriber/worker.rb
@@ -2,31 +2,39 @@ class Promiscuous::Subscriber::Worker
   include Promiscuous::Common::Worker
 
   def replicate
-    Promiscuous::AMQP.subscribe(subscribe_options) do |metadata, payload|
-      # Note: This code always runs on the root Fiber,
-      # so ordering is always preserved
-      begin
-        unless self.stop
-          Promiscuous.info "[receive] #{payload}"
-          self.unit_of_work { Promiscuous::Subscriber.process(JSON.parse(payload)) }
-          metadata.ack
-        end
-      rescue Exception => e
-        e = Promiscuous::Subscriber::Error.new(e, payload)
+    Promiscuous::AMQP.open_queue(queue_bindings) do |queue|
+      queue.subscribe :ack => true do |metadata, payload|
+        # Note: This code always runs on the root Fiber,
+        # so ordering is always preserved
+        begin
+          unless self.stop
+            Promiscuous.info "[receive] #{payload}"
+            self.unit_of_work { Promiscuous::Subscriber.process(JSON.parse(payload)) }
+            metadata.ack
+          end
+        rescue Exception => e
+          e = Promiscuous::Subscriber::Error.new(e, payload)
 
-        # TODO Discuss with Arjun about having an error queue.
-        self.stop = true
-        Promiscuous::AMQP.disconnect
-        Promiscuous.error "[receive] FATAL #{e} #{e.backtrace.join("\n")}"
-        Promiscuous.error "[receive] FATAL #{e}"
-        Promiscuous::Config.error_handler.try(:call, e)
+          self.stop = true
+          Promiscuous::AMQP.disconnect
+          Promiscuous.error "[receive] FATAL #{e} #{e.backtrace.join("\n")}"
+          Promiscuous.error "[receive] FATAL #{e}"
+          Promiscuous::Config.error_handler.try(:call, e)
+        end
       end
     end
   end
 
-  def subscribe_options
+  def queue_bindings
     queue_name = "#{Promiscuous::Config.app}.promiscuous"
+    exchange_name = Promiscuous::AMQP::EXCHANGE
+
+    if options[:personality]
+      queue_name    += ".#{options[:personality]}"
+      exchange_name += ".#{options[:personality]}"
+    end
+
     bindings = Promiscuous::Subscriber::AMQP.subscribers.keys
-    {:queue_name => queue_name, :bindings => bindings}
+    {:exchange_name => exchange_name, :queue_name => queue_name, :bindings => bindings}
   end
 end

--- a/lib/promiscuous/worker.rb
+++ b/lib/promiscuous/worker.rb
@@ -2,9 +2,12 @@ module Promiscuous::Worker
   mattr_accessor :workers
   self.workers = []
 
-  def self.replicate
-    self.workers << Promiscuous::Publisher::Worker.new
-    self.workers << Promiscuous::Subscriber::Worker.new
+  def self.replicate(options={})
+    publish   = options[:only].nil? || options[:only] == :publish
+    subscribe = options[:only].nil? || options[:only] == :subscribe
+
+    self.workers << Promiscuous::Publisher::Worker.new(options) if publish
+    self.workers << Promiscuous::Subscriber::Worker.new(options) if subscribe
     self.workers.each { |w| w.replicate }
   end
 

--- a/promiscuous.gemspec
+++ b/promiscuous.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |s|
   s.add_dependency("bunny")
   s.add_dependency("amqp")
   s.add_dependency("em-synchrony")
+  s.add_dependency("ruby-progressbar")
 
   s.files        = Dir["lib/**/*"] + ['README.md']
   s.require_path = 'lib'

--- a/spec/unit/promiscuous/subscribers/worker_spec.rb
+++ b/spec/unit/promiscuous/subscribers/worker_spec.rb
@@ -22,6 +22,6 @@ describe Promiscuous::Subscriber::Worker, '.subscribe' do
 
   it 'subscribes to the correct queue' do
     queue_name = 'test_subscriber.promiscuous'
-    sub_worker.subscribe_options[:queue_name].should == queue_name
+    sub_worker.queue_bindings[:queue_name].should == queue_name
   end
 end


### PR DESCRIPTION
1) Personalities for pub/sub.
It allows to use a separate exchange/queue_names when working with a
different personality. In our case, we use it with the "sync"
personality.

2) Split the original rake task
Instead of having one process for both publisher worker and subscriber
worker, we have one for each. This is important when it comes to
working with different personalities.

3) It has a progress bar (ruby-progressbar, not progressbar, and that generates warning if you are using both)
