### PR TITLE
Add :heartbeat

### DIFF
--- a/lib/promiscuous/amqp/bunny.rb
+++ b/lib/promiscuous/amqp/bunny.rb
@@ -3,7 +3,7 @@ module Promiscuous::AMQP:: Bunny
 
   def self.connect
     require 'bunny'
-    self.connection = ::Bunny.new(Promiscuous::Config.server_uri)
+    self.connection = ::Bunny.new(Promiscuous::Config.server_uri, { :heartbeat => Promiscuous::Config.heartbeat })
     self.connection.start
   end
 

--- a/lib/promiscuous/amqp/ruby_amqp.rb
+++ b/lib/promiscuous/amqp/ruby_amqp.rb
@@ -9,12 +9,13 @@ module Promiscuous::AMQP::RubyAMQP
       raise "Please use amqp://user:password@host:port/vhost" if uri.scheme != 'amqp'
 
       {
-        :host   => uri.host,
-        :port   => uri.port,
-        :scheme => uri.scheme,
-        :user   => uri.user,
-        :pass   => uri.password,
-        :vhost  => uri.path.empty? ? "/" : uri.path,
+        :host      => uri.host,
+        :port      => uri.port,
+        :scheme    => uri.scheme,
+        :user      => uri.user,
+        :pass      => uri.password,
+        :vhost     => uri.path.empty? ? "/" : uri.path,
+        :heartbeat => Promiscuous::Config.heartbeat
       }
     end
 

--- a/lib/promiscuous/config.rb
+++ b/lib/promiscuous/config.rb
@@ -1,5 +1,5 @@
 module Promiscuous::Config
-  mattr_accessor :app, :logger, :error_notifier, :backend, :server_uri, :queue_options
+  mattr_accessor :app, :logger, :error_notifier, :backend, :server_uri, :queue_options, :heartbeat
 
   def self.backend=(value)
     @@backend = "Promiscuous::AMQP::#{value.to_s.camelize.gsub(/amqp/, 'AMQP')}".constantize unless value.nil?
@@ -13,6 +13,7 @@ module Promiscuous::Config
     self.backend ||= defined?(EventMachine) && EventMachine.reactor_running? ? :rubyamqp : :bunny
     self.logger ||= defined?(Rails) ? Rails.logger : Logger.new(STDERR).tap { |l| l.level = Logger::WARN }
     self.queue_options ||= {:durable => true, :arguments => {'x-ha-policy' => 'all'}}
+    self.heartbeat ||= 60
 
     Promiscuous::AMQP.connect
   end


### PR DESCRIPTION
This solves the problem we were seeing when utilizing a load balancer. It will essentially poll rabbit every `:heartbeat` (default 60s) to ensure that the connection remains alive.
