### PR TITLE
Progress bar requirement in CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Rails Quick Tutorial
 
 ### 1. Preparation
 
-We need to few things for the promiscuous tutorial:
+We need a few things for the promiscuous tutorial:
 
 * The AMQP broker [RabbitMQ](http://www.rabbitmq.com/) up and running.
 * The key-value storage system [Redis](http://redis.io/) (at least 2.6) up and running.

--- a/lib/promiscuous/cli.rb
+++ b/lib/promiscuous/cli.rb
@@ -1,3 +1,5 @@
+require 'ruby-progressbar'
+
 class Promiscuous::CLI
   attr_accessor :options
 


### PR DESCRIPTION
I faced a problem when running `promiscuous publish`:

```
NameError: uninitialized constant Promiscuous::CLI::ProgressBar
```

It's in the gemspec, but is not required. It works well if the project where promiscuous is used has it in the gemfile, but not otherwise :)
