### PR TITLE
Active record 4.2.3 savepoints

### DIFF
--- a/lib/promiscuous/publisher/operation/active_record.rb
+++ b/lib/promiscuous/publisher/operation/active_record.rb
@@ -225,6 +225,8 @@ class ActiveRecord::Base
         end.rows.size
       else
         @connection.exec_update(@connection.to_sql(@arel, @binds), @operation_name, @binds).tap do
+          # NB: This works with Postgresql
+          # However I experienced errors when running with MariaDB/mysql2 adapter
           result = @connection.exec_query(sql_select_statment, @operation_name)
           @instances = result.map { |row| model.instantiate(row) }
         end

--- a/lib/promiscuous/publisher/operation/active_record.rb
+++ b/lib/promiscuous/publisher/operation/active_record.rb
@@ -27,8 +27,8 @@ class ActiveRecord::Base
               with_promiscuous_transaction_context { |tx| tx.start }
             end
 
-            def create_savepoint
-              create_savepoint_without_promiscuous
+            def create_savepoint(name = current_savepoint_name)
+              create_savepoint_without_promiscuous(name)
               with_promiscuous_transaction_context { |tx| tx.start }
             end
 
@@ -38,9 +38,9 @@ class ActiveRecord::Base
               @current_transaction_id = nil
             end
 
-            def rollback_to_savepoint
+            def rollback_to_savepoint(name = current_savepoint_name)
               with_promiscuous_transaction_context { |tx| tx.rollback }
-              rollback_to_savepoint_without_promiscuous
+              rollback_to_savepoint_without_promiscuous(name)
             end
 
             def commit_db_transaction
@@ -54,8 +54,8 @@ class ActiveRecord::Base
               @current_transaction_id = nil
             end
 
-            def release_savepoint
-              release_savepoint_without_promiscuous
+            def release_savepoint(name = current_savepoint_name)
+              release_savepoint_without_promiscuous(name)
               with_promiscuous_transaction_context { |tx| tx.commit }
             end
 


### PR DESCRIPTION
Update ActiveRecord publisher to be compatible with AR 4.2.3
and save points.

I'm not sure how backward compatible friendly this will be and
which other versions prior to 4.2.3 use save points.
